### PR TITLE
Downloader skips samples with very large forces

### DIFF
--- a/downloader/config.yaml
+++ b/downloader/config.yaml
@@ -28,3 +28,8 @@ values:
   - 'SCF QUADRUPOLE'
   - 'WIBERG LOWDIN INDICES'
   - 'MAYER INDICES'
+
+# This specifies a cutoff on forces.  A sample will be skipped if any component of the force on any atom
+# is larger than this value (in hartree/bohr).  Comment out this line to include all samples regardless of
+# force magnitude.
+max_force: 1.0


### PR DESCRIPTION
By default it sets the cutoff to 1 hartree/bohr, which is about 5x larger than the very largest forces in typical MD simulations.  It can be configured by the user.

Fixes #40.