### PR TITLE
Updated README with Zenodo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # SPICE: A Dataset for Training Machine Learning Potentials
 
+This repository contains scripts and data files used in the creation of the SPICE dataset.  It does not contain the
+dataset itself.  That is available from Zenodo:
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7258940.svg)](https://doi.org/10.5281/zenodo.7258940)
+
 SPICE (Small-Molecule/Protein Interaction Chemical Energies) is a collection of quantum mechanical data for
 training potential functions.  The emphasis is particularly on simulating drug-like small molecules interacting
 with proteins.  It is designed to achieve the following goals.
@@ -45,23 +50,6 @@ conformations, the range of sizes spanned by the molecules/clusters, and the lis
 |Ion Pairs|28|1426|2|Li, F, Na, Cl, K, Br, I|
 |Total|19238|1132808|2–96|H, Li, C, N, O, F, Na, Mg, P, S, Cl, K, Ca, Br, I|
 
-## Getting The Data
-
-This repository contains scripts and data files used in creating the dataset.  The SPICE dataset itself
-is hosted on [QCArchive](https://qcarchive.molssi.org/).  It can be obtained in a few ways.
-
-First, the [Releases page](https://github.com/openmm/spice-dataset/releases) provides the data for each
-release as a single HDF5 file.  Because some data types can be very large, these files include only the
-most commonly used results: total energies, formation energies, and forces.
-
-Second, the [downloader script](https://github.com/openmm/spice-dataset/tree/main/downloader) can be used
-to create a HDF5 file with whatever data fields you need.  This is useful when you want less commonly used
-fields, such as bond orders or atomic multipoles.  The page linked above describes the format of the HDF5
-files and has instructions on how to configure what information to download.
-
-Third, the data can be retrieved using the [QCPortal library](https://docs.qcarchive.molssi.org/projects/QCPortal/en/stable/).
-It provides a programmatic API for querying and accessing data.
-
 ## Citing The Dataset
 
 Please cite this manuscript for papers that use the SPICE dataset:
@@ -70,5 +58,5 @@ Peter Eastman, Pavan Kumar Behara, David L. Dotson, Raimondas Galvelis, John E. 
 John D. Chodera, Benjamin P. Pritchard, Yuanqing Wang, Gianni De Fabritiis, and Thomas E. Markland.  "SPICE, A Dataset
 of Drug-like Molecules and Peptides for Training Machine Learning Potentials."  https://doi.org/10.48550/arXiv.2209.10702 (2022).
 
-In addition, Zenodo automatically generates a DOI for every release of the dataset, which can be found on the Releases
-page.  It can be cited along with the above paper if you want to cite a particular version of the dataset.
+To cite a particular version of the dataset, cite the Zenodo DOI found on the Releases page and shown above for the
+most recent version.


### PR DESCRIPTION
At recent meeting, we learning that QCArchive isn't really intended to function as a long term repository, and we decided to post the dataset to Zenodo instead.  This updates the README accordingly.

By the way, I wasn't able to find ORCID IDs for everyone.  Please check the Zenodo page.  If you have one and it isn't shown, send it to me and I can add it.