### PR TITLE
Account for inconsistency in naming of data fields

### DIFF
--- a/downloader/downloader.py
+++ b/downloader/downloader.py
@@ -115,10 +115,17 @@ for subset in config['subsets']:
         ds = group.create_dataset('formation_energy', data=np.array([vars['DFT TOTAL ENERGY']-ref_energy for vars in qcvars]), dtype=np.float64)
         ds.attrs['units'] = 'hartree'
         for value in config['values']:
-            key = value.lower().replace(' ', '_')
+            altvalue = value.replace(' ', '_')
+            key = altvalue.lower()
             try:
+                data = []
+                for vars in qcvars:
+                    if value in vars:
+                        data.append(vars[value])
+                    else:
+                        data.append(vars[altvalue])
                 dtype = np.float64 if 'energy' in key else np.float32
-                ds = group.create_dataset(key, data=np.array([vars[value] for vars in qcvars]), dtype=dtype)
+                ds = group.create_dataset(key, data=np.array(data), dtype=dtype)
                 if key in units:
                     ds.attrs['units'] = units[key]
             except KeyError:


### PR DESCRIPTION
Fixes #76.  In most cases, the names of data fields use spaces between words, for example "DFT TOTAL ENERGY" or "MBIS CHARGES".  But in a subset of records, the fields for bond orders use underscores between words instead: "WIBERG_LOWDIN_INDICES" and "MAYER_INDICES".  This caused bond orders to be missing for some molecules.  I changed the downloader script to accept either name.

I'll rerun the script and upload a new file to Zenodo as 1.1.4.